### PR TITLE
- Event reset notification now has a delay at login to make sure the …

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+- Event reset notification now has a delay at login to make sure the text displays after UI load.
+- Added event names to the trade cooldowns to fix issue where they weren't displaying.
+- Events from all characters are now checked.
+
 v2.0.6-Alpha
 - Event editor now saves attending like on the non-trusted tab to avoid setting the user as not attending by default.
 - Comment is preserved when saving on event editor.

--- a/GroupCalendar.lua
+++ b/GroupCalendar.lua
@@ -498,7 +498,7 @@ GroupCalendar_cCooldownItemInfo =
 
 function GroupCalendar_CheckItemCooldowns()	
 	-- Remove the existing saved info	
-	EventDatabase_RemoveSavedInstanceEvents(gGroupCalendar_UserDatabase, vCurrentServerDate, vCurrentServerTime);
+	EventDatabase_RemoveSavedInstanceEvents();
 
 	for vBagIndex = 0, NUM_BAG_SLOTS do
 		local	vNumBagSlots = GetContainerNumSlots(vBagIndex);
@@ -901,7 +901,7 @@ function GroupCalendar_Update(self, pElapsed)
 		gGroupCalendar_ExpiredEventsTime = 0;
 		
 		-- Remove the existing saved info	
-		EventDatabase_RemoveSavedInstanceEvents(gGroupCalendar_UserDatabase);
+		EventDatabase_RemoveSavedInstanceEvents();
 
 	end
 


### PR DESCRIPTION
- Event reset notification now has a delay at login to make sure the text displays after UI load.
- Added event names to the trade cooldowns to fix issue where they weren't displaying.
- Events from all characters are now checked.